### PR TITLE
Fixes #2 how to serve static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It looks like this:
 
 ## Dockerflow Specification
 
-### A containerized app must...
+### Containerized App Requirements
 
 1. Accept its configuration through environment variables
 1. Listen on environment variable `$PORT` for HTTP requests
@@ -45,15 +45,14 @@ It looks like this:
 1. Have a `USER app` command to set the default user.
 1. Have a `ENTRYPOINT` and `CMD` commands which starts the service and listens on `$PORT`.
 
-See [Guidelines for Building a Container](docs/building-container.md) for more tips on making a production ready container.
+### Containerized App Recommendations
+
+1. [Static files should be served by the application](docs/serving-static-content.md)
+1. [Containers should be optimized for production use](docs/building-container.md)
 
 ## Automated CI and Container creation
 
 See [Automating The Build](docs/automating-build.md) for information on using CI tools to build, test and deploy the container to Dockerhub.
-
-## Misc
-
-* [Serving static content](docs/serving-static-content.md) 
 
 ## Contributing
 * [Contribution Guidelines](CONTRIBUTE.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # About
 
-Dockerflow is a specification for how to dockerize Cloud Services' web applications so they are easy to deploy and share common behaviour. 
+Dockerflow is a specification for how to dockerize web applications so they are easy to deploy and share common behaviour. 
 
 The specification is this README.md file. This repo contains a reference application that will change with the specification. See the [Contribution document](CONTRIBUTE.md) for details on suggesting changes and providing feedback.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ See [Guidelines for Building a Container](docs/building-container.md) for more t
 
 See [Automating The Build](docs/automating-build.md) for information on using CI tools to build, test and deploy the container to Dockerhub.
 
+## Misc
+
+* [Serving static content](docs/serving-static-content.md) 
+
 ## Contributing
 * [Contribution Guidelines](CONTRIBUTE.md)
 

--- a/docs/serving-static-content.md
+++ b/docs/serving-static-content.md
@@ -10,7 +10,7 @@ When using transpiling tools like [bablejs](https://babeljs.io/), [sass](http://
 
 ## How to serve static content
 
-### Serve it with the application
+### Serve assets with the application
 
 This is the recommended approach. It is the most idiomatic usage of containers to hide application dependencies from the host machine. For Dockerflow applications the docker host only needs to provide a `$PORT` and need not be concerned about what's inside. 
 
@@ -22,18 +22,13 @@ The downside is that applications may be more complex with additional dependenci
 
 If performance is important it is recommended to use nginx as a reverse *caching* proxy in front of the container. nginx will respect `Cache-Control` headers and serve assets as fast as the machine can handle. This setup would be dependent on the hosting service.
 
-### Serve it from the Docker host machine
+### Serve assets outside the container
 
-An alternative is to serve it from the Docker host machine directly. Some installations favor containers as a packaging and distribution solution over standard system packages like RPM. 
+An alternative is to copy static assets out and serve them elsewhere. This approach is discouraged but is acceptable for specific application requirements. 
 
-In these situations the Docker host machine needs to run a reverse proxy like nginx to route requests for static assets to a directory and dynamic requests to the application. 
+In this situation a process will copy out the static assets, relocate them and configure external hosting services. 
 
-For this to work the hosting service must:
-
-1. Copy static assets out of the container onto the host machine.
-2. Configure nginx to route requests appropriately.
-
-To copy static assets out of the container the host machine uses a command like:
+Copying out assets can be done like so:
 
 ```
 docker run --rm \
@@ -45,4 +40,4 @@ docker run --rm \
 1. A directory on the host machine is volume mounted into the container
 2. A shell command is used to copy assets out onto the host machine
 
-The greatest downside to this approach is the tight coupling between the host's deployment code and the application. The host machine's configuration has to be kept lockstep with the application's logic. Any changes to either will break the full functionality of the service. 
+Serving assets outside the container has additional overhead and risks. Changes to the hosting service, the assets or the configuration of the container can cause service disruption if things aren't kept in sync. 

--- a/docs/serving-static-content.md
+++ b/docs/serving-static-content.md
@@ -1,0 +1,48 @@
+# Serving Static Content
+
+Dockerflow is focused on making backend code easy to deploy and run. It purposefully avoids adding requirements for how to serve front end assets. However, it is unrealistic to ignore the tight coupling between frontend assets and backend functionality. This document offers recommendations for developers on how to bundle static assets into their containers to simplify hosting. 
+
+It is up to the developer to choose the suitable method based on where their application and its assets will be hosted.
+
+## Generated static assets
+
+When using transpiling tools like [bablejs](https://babeljs.io/), [sass](http://sass-lang.com/) and [browserify](http://browserify.org/) only have their output and not the source in the container. Use a [.dockerignore](https://github.com/mozilla/testpilot/blob/master/.dockerignore) file to exclude source directories. If source materials are required it is OK to include them in the container to be used at run time. 
+
+## How to serve static content
+
+### Serve it with the application
+
+This is the recommended approach. It is the most idiomatic usage of containers to hide application dependencies from the host machine. For Dockerflow applications the docker host only needs to provide a `$PORT` and need not be concerned about what's inside. 
+
+Additionally the application has full control over HTTP headers. Business logic for cache controls lives with the rest of the business rules. Downstream CDNs, proxies and web caches are simplified as logic does not need to be replicated in multiple places. 
+
+Applications are more portable when they serve their own static assets. PaaS providers like Heroku, Google Cloud Platform, AWS Elastic Beanstalk and many others can directly host the application without customization.
+
+The downside is that applications may be more complex with additional dependencies. They need to read bytes from disk and turn it into an HTTP response. Also serving static assets through an application is often slower than an optimized web server like nginx. 
+
+If performance is important it is recommended to use nginx as a reverse *caching* proxy in front of the container. nginx will respect `Cache-Control` headers and serve assets as fast as the machine can handle. This setup would be dependent on the hosting service.
+
+### Serve it from the Docker host machine
+
+An alternative is to serve it from the Docker host machine directly. Some installations favor containers as a packaging and distribution solution over standard system packages like RPM. 
+
+In these situations the Docker host machine needs to run a reverse proxy like nginx to route requests for static assets to a directory and dynamic requests to the application. 
+
+For this to work the hosting service must:
+
+1. Copy static assets out of the container onto the host machine.
+2. Configure nginx to route requests appropriately.
+
+To copy static assets out of the container the host machine uses a command like:
+
+```
+docker run --rm \
+   -v /path/on/host:/path/in/container \          [1]
+   <repo>:<tag> \
+   cp -R /app/path/to/static/* /path/in/container [2]
+```
+
+1. A directory on the host machine is volume mounted into the container
+2. A shell command is used to copy assets out onto the host machine
+
+The greatest downside to this approach is the tight coupling between the host's deployment code and the application. The host machine's configuration has to be kept lockstep with the application's logic. Any changes to either will break the full functionality of the service. 


### PR DESCRIPTION
@chuckharmston r? please
@lmorchard r? as well since this will also affect TestPilot

This is the initial draft on how Dockerflow application should serve static assets.
TL;DR: from the application and cached with a reverse proxy for performance.