### PR TITLE
Removes Universal Search from example list.

### DIFF
--- a/docs/building-container.md
+++ b/docs/building-container.md
@@ -5,7 +5,6 @@
 * [BrowserID Verifier - Node 4](https://github.com/mozilla/browserid-verifier/blob/master/Dockerfile)
 * [Tokenserver - Python 2.7](https://github.com/mozilla-services/tokenserver/blob/master/Dockerfile)
 * [TestPilot - Python 3](https://github.com/mozilla/testpilot/blob/master/Dockerfile)
-* [Universal Search Recommendation - Python 3.5](https://github.com/mozilla/universal-search-recommendation/blob/master/app/Dockerfile)
 
 ### Dockerfile Guidelines
 


### PR DESCRIPTION
I'm not comfortable with it being used as an example. It's not fully-baked and will probably go through substantial refactoring before deployment; it was designed as a multiple-container application.