### PR TITLE
Tweak Dockerflow spec to REQUIRE a "build" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Dockerflow allows any automated build and test tool that meets these requirement
 
 1. Log to `stdout` in the [mozlog](docs/mozlog.md) json schema. 
 1. [Containers should be optimized for production use](docs/building-container.md).
-1. CI builds should generate a docker-image-shasum256.txt file containing *only* the sha256 for the generated docker image.
+1. CI builds should generate a `docker-image-shasum256.txt` ([example](https://circle-artifacts.com/gh/mozilla-services/Dockerflow/37/artifacts/0/tmp/circle-artifacts.SboyKpb/docker-image-shasum256.txt)) file containing *only* the sha256 hash for the docker image.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Dockerflow allows any automated build and test tool that meets these requirement
 
 1. Accept its configuration through environment variables
 1. Listen on environment variable `$PORT` for HTTP requests
-1. Respond to `/__version__` with a JSON object like: `{"source":"url to repo", "version":"human readable string", "commit":"git hash"}`
+1. Respond to `/__version__` with a [JSON object](docs/version-object.md).
 1. Respond to `/__heartbeat__` with a HTTP 200 or 5xx on error. This should check backing services like a database for connectivity.
 1. Respond to `/__lbheartbeat__` with an HTTP 200. This is for load balancer checks and should **not** check backing services.
 1. Send text logs to `stdout` or `stderr`. 
@@ -57,10 +57,12 @@ Dockerflow allows any automated build and test tool that meets these requirement
 1. Use `USER app` to set the default user.
 1. Have a `ENTRYPOINT` and `CMD` commands which starts the service.
 
-### Containerized App Recommendations
+### Optional Recommendations
 
-1. [Containers should be optimized for production use](docs/building-container.md)
-1. Send logs to `stdout` in the [mozlog](docs/mozlog.md) json schema. 
+1. Log to `stdout` in the [mozlog](docs/mozlog.md) json schema. 
+1. [Containers should be optimized for production use](docs/building-container.md).
+1. CI builds should generate a docker-image-shasum256.txt file containing *only* the sha256 for the generated docker image.
+
 
 ## Contributing
 * [Contribution Guidelines](CONTRIBUTE.md)

--- a/circle.yml
+++ b/circle.yml
@@ -10,24 +10,15 @@ machine:
     - docker
 
 dependencies:
-  # make sure to keep the docker cache dir
-  cache_directories:
-    - "~/docker"
-
   override:
     - docker info
 
-    # build the container, use circleci's docker cache workaround
-    # only use 1 image per day to keep the cache size from getting 
-    # too big and slowing down the build
-    - I="image-$(date +%j).tar"; if [[ -e ~/docker/$I ]]; then echo "Loading $I"; docker load -i ~/docker/$I; fi
-
     # create a version.json
-    - printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" > version.json
+    - printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" > version.json
     - docker build -t app:build .
 
-    # Clean up any old images and save the new one
-    - I="image-$(date +%j).tar"; mkdir -p ~/docker; rm ~/docker/*; docker save app:build > ~/docker/$I; ls -l ~/docker
+    # write the sha256 sum to an artifact to make image verification easier
+    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
 
 test:
   override:

--- a/docs/version_object.md
+++ b/docs/version_object.md
@@ -1,0 +1,20 @@
+# Version Object
+
+A Dockerflow containers are required to respond to requests to `/__version__` with a JSON object that looks like:
+
+```json
+{
+  "source" : "https://github.com/mozilla-services/Dockerflow", 
+  "version": "release tag or string for humans", 
+  "commit" : "<git hash>",
+  "build"  : "uri to CI build job"
+}
+```
+
+The version objects provides enough information to identify:
+
+1. Where to find the source code
+2. The release version of the application
+  - can be left blank for non-release versions
+3. The commit hash for the containerized application
+4. A link to the CI tool's build job that created the image


### PR DESCRIPTION
- Change the version object for `__version__` to REQUIRE a `build` key, which contains a URL to the CI build job
- add RECOMMENDATION for CI job to generate a docker-image-shasum256.txt file which can be used to verify the integrity of the container 

This paves the way for basic verification of a docker image without having to completely switch to Docker's implementation of the TUF framework. The new requirements and recommendations have already been prototyped / tried with: 

* mozilla/balrog - [build](https://tools.taskcluster.net/task-inspector/#TpS9x4roT_i4MM__tcr27Q/0) | [docker-image-shasum256.txt](https://public-artifacts.taskcluster.net/TpS9x4roT_i4MM__tcr27Q/0/public/docker-image-shasum256.txt)
* mozilla-services/mozilla-idp - [build](https://circleci.com/gh/mozilla-services/mozilla-idp/23) | [docker-image-shasum256.txt](https://circle-artifacts.com/gh/mozilla-services/mozilla-idp/23/artifacts/0/tmp/circle-artifacts.kvOBFl8/docker-image-shasum256.txt)
