### PR TITLE
Improve wording and clarity around the JSON version object

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 
 # Dockerflow
 
-Dockerflow is a specification for automated building, testing and publishing of web application containers that comply to a common set of behaviours. Compliant web containers are simpler to deploy, monitor and manage in production.
+Dockerflow is a specification for automated building, testing and publishing of docker web application images that comply to a common set of behaviours. Compliant images are simpler to deploy, monitor and manage in production.
 
 The specification is this README.md file. This repo contains a reference application that will change with the specification. See the [Contribution document](CONTRIBUTE.md) for details on suggesting changes and providing feedback.
-
-**This is still a work in progress and may subject to change.** When the specification has stabilized a tag will be created on this repository.
 
 ## Automated Creation Pipeline
 
@@ -19,14 +17,14 @@ The specification is this README.md file. This repo contains a reference applica
 
 ````
 
-1. Code pushed to github triggers the flow
-2. CI builds and tests the container
-3. Tested containers are published to Docker Hub.
-4. Container pull from Docker Hub to be used
+1. A Code push triggers automated image building
+2. CI builds and tests the image
+3. Tested images are published to Docker Hub.
+4. Images are pulled from Docker Hub to be used
 
 ## Specification
 
-The specification has requirements that a container must comply with. Recommendations are optional but encouraged if they are appropriate for the application.
+The specification has requirements that a container must comply with. Recommendations are optional but encouraged if they are suitable for the application.
 
 ### Building and Testing
 
@@ -34,35 +32,37 @@ Dockerflow allows any automated build and test tool that meets these requirement
 
 1. Able to trigger a build from a code change like a pull request or a merge.
 1. Able to run tests on the code and the application in the container.
-1. Able to manually re-run a build and test.
-1. Able to publish container to Docker Hub
+1. Able to manually trigger a previous build and test.
+1. Able to publish container to Docker Hub.
 1. Able to provide a build and test log.
-1. Reasonably secure and keep secrets from being exposed.
+1. Secure and keeps secrets from being exposed.
 
 ### Containerized App Requirements
 
-1. Accept its configuration through environment variables
-1. Listen on environment variable `$PORT` for HTTP requests
-1. Respond to `/__version__` with a [JSON object](docs/version-object.md).
+When the application is ran in the container it must:
+
+1. Accept its configuration through environment variables.
+1. Listen on environment variable `$PORT` for HTTP requests.
+1. Must have a [JSON version object](docs/version_object.md) at `/app/version.json`.
+1. Respond to `/__version__` with the contents of `/app/version.json`.
 1. Respond to `/__heartbeat__` with a HTTP 200 or 5xx on error. This should check backing services like a database for connectivity.
 1. Respond to `/__lbheartbeat__` with an HTTP 200. This is for load balancer checks and should **not** check backing services.
 1. Send text logs to `stdout` or `stderr`. 
-1. [Static files should be served by the application](docs/serving-static-content.md)
+1. Serve its own [static content](docs/serving-static-content.md).
 
 ### Dockerfile requirements
 
 1. Sources should be copied to the `/app` directory in the container.
 1. Create an `app` group with a GID of `10001`.
-1. Create an `app` user with a UID of `10001`. Should be a member of the `app` group.
-1. Use `USER app` to set the default user.
-1. Have a `ENTRYPOINT` and `CMD` commands which starts the service.
+1. Create an `app` user with a UID of `10001` and is a member of the `app` group.
+1. Have both `ENTRYPOINT` and `CMD` instructions to start the service.
+1. Have a `USER app` instruction to set the default user.
 
 ### Optional Recommendations
 
 1. Log to `stdout` in the [mozlog](docs/mozlog.md) json schema. 
 1. [Containers should be optimized for production use](docs/building-container.md).
 1. CI builds should generate a `docker-image-shasum256.txt` ([example](https://circle-artifacts.com/gh/mozilla-services/Dockerflow/37/artifacts/0/tmp/circle-artifacts.SboyKpb/docker-image-shasum256.txt)) file containing *only* the sha256 hash for the docker image.
-
 
 ## Contributing
 * [Contribution Guidelines](CONTRIBUTE.md)

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,15 @@ dependencies:
     - docker info
 
     # create a version.json
-    - printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" > version.json
+    - >
+        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
+        "$CIRCLE_SHA1" 
+        "$CIRCLE_TAG"
+        "$CIRCLE_PROJECT_USERNAME"
+        "$CIRCLE_PROJECT_REPONAME"
+        "$CIRCLE_BUILD_URL"
+        > version.json
+
     - docker build -t app:build .
 
     # write the sha256 sum to an artifact to make image verification easier


### PR DESCRIPTION
- Fix bugs in the spec
- Clarify requirements around the JSON version object
  - must be available under `/app/version.json` in the image
  - this is to make automatic verification easier
- Remove WIP header, nearing in on a 1.0 specification