### PR TITLE
use the Config.Image value to aid in verification

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ dependencies:
     - docker build -t app:build .
 
     # write the sha256 sum to an artifact to make image verification easier
-    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
+    - docker inspect --format '{{json .Config.Image}}' app:build | tr -d '"''"' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
 
 test:
   override:


### PR DESCRIPTION
- using the value from `docker images` is not reliable. That sha256 changes
- using `.Config.Image` from `docker inspect` appears to be a lot more reliable 
  - an image built on a centos7 w/ docker 1.8 and pulled to OSX docker beta ver 1.11 has the same value
  - seems to be bit more reliable and better than the `docker images` route