### PR TITLE
install openssh-client git & git on docker-in-docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,12 @@ jobs:
       - image: docker:18.02.0-ce
     working_directory: /dockerflow
     steps:
+      # workaround circleci's fallback git's "object not found" error w/ tag
+      # builds
+      - run:
+          name: Install Docker build dependencies
+          command: apk add --no-cache openssh-client git
+
       - checkout
       - setup_remote_docker
 


### PR DESCRIPTION
I've seen circleci2's fallback git fail with an obscure "object not found" error during tag builds on more than one project now

I'm not sure anyone else has hit this, but it's not easy to diagnose when it happens -- so just in case I'm inclined to include the workaround here

