### PR TITLE
Recommend running one process

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ When the application is ran in the container it must:
 
 ### Optional Recommendations
 
+1. Each instance of a container should only run one process. If you need to run two processes, just create another instance of the container & run a different command.
 1. Log to `stdout` in the
    [mozlog](https://wiki.mozilla.org/Firefox/Services/Logging) json schema.
 1. [Containers should be optimized for production use](docs/building-container.md).
-1. Containers should only run a single process.
 1. Listen on port 8000.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ When the application is ran in the container it must:
 1. Log to `stdout` in the
    [mozlog](https://wiki.mozilla.org/Firefox/Services/Logging) json schema.
 1. [Containers should be optimized for production use](docs/building-container.md).
+1. Containers should only run a single process.
 1. Listen on port 8000.
 
 ## Contributing


### PR DESCRIPTION
I think there's a number of reasons to run only one process. It lets us more reliably detect whether a container is still running everything we need it to, it lets us generate a coherent stream of logs, etc.

I'm unsure whether to explicitly mention that it's okay to run a single master process that manages its own worker processes (e.g. uwsgi). Another way to accomplish that might be to say "program" rather than "process".