### PR TITLE
Convert sample app to express framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:12-slim
 
 # add a non-privileged user for running the application
 RUN groupadd --gid 10001 app && \

--- a/package.json
+++ b/package.json
@@ -12,16 +12,15 @@
   "bugs": "https://github.com/mozilla-services/dockerflow/issues",
   "main": "server.js",
   "engines": {
-    "node": ">=4.2.0"
+    "node": ">=12.13.0"
   },
   "dependencies": {
-    "httpdispatcher":"1.0.0",
-    "mozlog":"2.0.2"
+    "express": "4.17.1",
+    "mozlog": "2.1.0"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "scripts": {
     "start": "node server.js",
-    "test" : "cat version.json; true"
+    "test": "cat version.json; true"
   }
 }


### PR DESCRIPTION
Express is the most commonly used severside javascript framework in use
at Mozilla AFAICT,, so it is a better starting point for a sample app.

```
$ docker run -p 127.0.0.1:8000:8000/tcp c97a23679442 &
[1] 92532
$ 
> Dockerflow@0.0.1 start /app
> node server.js

{"Timestamp":1588948237539000000,"Logger":"dockerflow-demo","Type":"general.server","Severity":6,"Pid":17,"EnvVersion":"2.0","Fields":{"msg":"listening","port":"8000"}}

$ curl localhost:8000/__heartbeat__
{"status":"ok","checks":{"version_file_exists":"ok"},"details":{}}
```