### PR TITLE
Base circleci cache key on git sha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: docker save app:build
           command: mkdir -p /cache; docker save -o /cache/docker.tar "app:build"
       - save_cache:
-          key: v1-{{ .Branch }}-{{epoch}}
+          key: v1-{{ .Environment.CIRCLE_SHA1 }}-{{epoch}}
           paths:
             - /cache/docker.tar
 
@@ -45,7 +45,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
           name: Restore Docker image cache
           command: docker load -i /cache/docker.tar
@@ -60,7 +60,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
           name: Restore Docker image cache
           command: docker load -i /cache/docker.tar


### PR DESCRIPTION
This should prevent the issue of one workflow loading the cache from
another when running concurrently that is described in #44