### PR TITLE
Log in to docker hub before pulling images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     docker:
       - image: docker:stable-git
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     working_directory: /dockerflow
     steps:
       - checkout
@@ -24,6 +27,15 @@ jobs:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
+
+      - run:
+          name: Login to Dockerhub
+          command: |
+            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+              echo "Skipping Login to Dockerhub, credentials not available."
+            else
+              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+            fi
 
       - run:
           name: Build Docker image


### PR DESCRIPTION
Beginning 2020-11-2 Docker Hub is rate limiting anonymous image pulls per IP address. This will impact our jobs that run on CircleCI. We have a paid account with Docker Hub, which is not subject to rate limiting. To avoid the limits, we need to
log in before we pull. That happens in two places

1) In all job to fetch the image that the CircleCI jobs run in. This is what the new `auth` block handles.

2) In the build job to pull the base image defined in the application's dockerfile. This is that the new "login to dockerhub" step handles

We still have to log in during the deploy job before pushing to docker hub, since there is no shared state between jobs.

Logging in will only work for the main repo, it will not work for forks. For security reasons, CircleCI does not share environment variables with jobs run in forks.

h/t to @jwhitlock who figured most of this out in https://github.com/mozilla/ichnaea/compare/6655b9b...f8da96dc28