### PR TITLE
Suggestion: Add Github Actions to supported build platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Dockerflow requires an automated build and test tool that meets these requiremen
 1. Able to provide a build and test log.
 1. Secure and keeps secrets from being exposed.
 
-Within Mozilla, we support the use of CircleCI or Taskcluster.
+Within Mozilla, we support the use of CircleCI, Taskcluster, or Github Actions.
 
 ### Containerized App Requirements
 


### PR DESCRIPTION
On https://github.com/mozilla-it/ctms-api, we're using [GitHub Actions](https://github.com/features/actions) for building and testing. Add this to CircleCI and Taskcluster as supported builders.